### PR TITLE
NUEntity.isFromTemplate

### DIFF
--- a/NUEntity.js
+++ b/NUEntity.js
@@ -183,4 +183,8 @@ export default class NUEntity extends NUObject {
                 ? { ...acc, [key.substring(1)]: value } : acc;
         }, {});
     }
+    
+    isFromTemplate() {
+        return this.hasOwnProperty('templateID') && this.templateID;
+    }
 }


### PR DESCRIPTION
`isTemplate` can be directly invoked. No separate method needed.