### PR TITLE
Updated NUService.count()

### DIFF
--- a/NUService.js
+++ b/NUService.js
@@ -233,9 +233,11 @@ export default class NUService extends NUObject {
     count(RESTResourceName, parentEntity, page, filter, orderBy, filterType) {
         return this.invokeRequest(
             'HEAD', this.buildURL(null, RESTResourceName, parentEntity), this.computeHeaders(page, filter, orderBy, filterType)).then(
-                response => Number(response.headers[this.headerCount.toLowerCase()],
-            ),
-        );
+                response => {
+                    const count = Number(response.headers[this.headerCount.toLowerCase()]);
+                    return count || 0;
+                }
+            );
     }
 
     /*


### PR DESCRIPTION
For https://github.com/nuagenetworks/vsd-react-ui/issues/1011

`NUService.count()` should now return `0` if proper request headers are missing.