### PR TITLE
PATCH support

### DIFF
--- a/NURESTConnection.js
+++ b/NURESTConnection.js
@@ -271,4 +271,10 @@ export default class NURESTConnection extends NUObject {
         return this.makeRequest(url, 'HEAD', headers);
     }
 
+    /*
+      Invokes a PATCH request on the server
+    */
+    makePATCHRequest(url, headers, body) {
+        return this.makeRequest(url, 'PATCH', headers, body);
+    }
 }


### PR DESCRIPTION
- making use of already existing NUEntity.associatedEntities
- I clone the service with custom header 'X-Nuage-PatchType' and make use of the clone to invoke the patch request