### PR TITLE
NURESTConnection - handle network error

### DIFF
--- a/NURESTConnection.js
+++ b/NURESTConnection.js
@@ -17,7 +17,14 @@ class ResponseCodeEnum extends Enum {
         return ResponseCodeEnum.getClassName();
     }
 
-    static getErrors(response) {
+    static getErrors(error) {
+        const { response, message } = error;
+        if (!response) {
+            getLogger().error(`<<<< Error response without status: ${message}`);
+            return {
+                data: message
+            }
+        }
         switch (response.status) {
             case 400:
             case 401:
@@ -194,7 +201,7 @@ export default class NURESTConnection extends NUObject {
                 // server returned with some sort of error response
                 const {response} = error;
                 const result = response ? {headers: {...response.headers}, response} : {};
-                const errors = ResponseCodeEnum.getErrors(response);
+                const errors = ResponseCodeEnum.getErrors(error);
                 if (response) {
                     //handle error
                     if (response.status === 401) {


### PR DESCRIPTION
- In case of network error (for example, I hold the call on server), the error object in catch block does not contain a response property. In such a case just logging the message contaned in error object. 