### PR TITLE
VSD-34542: change tabify - remove empty meta in ES6.7 response

### DIFF
--- a/elasticsearch/ESTabify.js
+++ b/elasticsearch/ESTabify.js
@@ -161,6 +161,7 @@ export default class ESTabify {
         /*
             The below delete meta was necessitated by https://github.com/elastic/elasticsearch/pull/28185
             Though no aggregation metadata was specified in the query, the query response may have an empty meta object
+            This behavior has been observed from Elastic Search 6.7
             The below block of code deletes the empty meta such that it does not impact tabification logic
         */
         if (node.meta && _.isEmpty(node.meta)) {

--- a/elasticsearch/ESTabify.js
+++ b/elasticsearch/ESTabify.js
@@ -158,6 +158,15 @@ export default class ESTabify {
         if (!node)
             return;
 
+        /*
+            The below delete meta was necessitated by https://github.com/elastic/elasticsearch/pull/28185
+            Though no aggregation metadata was specified in the query, the query response may have an empty meta object
+            The below block of code deletes the empty meta such that it does not impact tabification logic
+        */
+        if (node.meta && _.isEmpty(node.meta)) {
+            delete node.meta;
+        }
+
         const keys = Object.keys(node);
 
         // Use old school `for` so we can break control flow by returning.


### PR DESCRIPTION
This is related to https://github.com/elastic/elasticsearch/pull/28185
Though no aggregation metadata was specified in the query, the query response may have an empty meta object.
This change deletes the empty meta such that it does not impact tabification logic