### PR TITLE
Ignore UI internal attributes in Inspect modal

### DIFF
--- a/NUAbstractModel.js
+++ b/NUAbstractModel.js
@@ -50,10 +50,14 @@ export default class NUAbstractModel extends NUObject {
         return this.buildJSON();
     }
 
-    toObject() {
+    toObject(props = {}) {
+        const {isInspect = false} = props;
         const attributeDescriptors = this.constructor.attributeDescriptors;
         const obj =  {};
         Object.entries(attributeDescriptors).forEach(([localName, attributeObj]) => {
+            if (isInspect && attributeObj.isInternal) {
+                return;
+            }
             let value = this[localName];
             if (value) {
                 if (attributeObj.attributeType === NUAttribute.ATTR_TYPE_OBJECT && attributeObj.subType) {

--- a/NUAttribute.js
+++ b/NUAttribute.js
@@ -48,6 +48,7 @@ export default class NUAttribute extends NUObject {
             remoteName: remName,
             subType: obj.subType,
             userlabel: obj.userlabel,
+            isInternal: obj.isInternal,
         });
     }
 

--- a/NUEntity.js
+++ b/NUEntity.js
@@ -50,11 +50,13 @@ export default class NUEntity extends NUAbstractModel {
         associatedEntities: new NUAttribute({
           localName: 'associatedEntities',
           attributeType: NUAttribute.ATTR_TYPE_LIST,
-          isEditable: true }),
+          isEditable: true,
+          isInternal: true }),
         associatedEntitiesResourceName: new NUAttribute({
           localName: 'associatedEntitiesResourceName',
           attributeType: NUAttribute.ATTR_TYPE_STRING,
-          isEditable: true }),
+          isEditable: true,
+          isInternal: true }),
     }
 
     static getSearchableAttributes() {
@@ -123,13 +125,13 @@ export default class NUEntity extends NUAbstractModel {
         return this._validationErrors;
     }
 
-    toObject() {
+    toObject(props) {
         const attributeDescriptors = this.constructor.attributeDescriptors;
         const assocEntities = this[attributeDescriptors.associatedEntities.name];
         if (assocEntities && assocEntities.length > 0) {
           return assocEntities.map(item => item.ID);
         } else {
-            return super.toObject();
+            return super.toObject(props);
         }
     }
 


### PR DESCRIPTION
- based on a boolean flag passed, attributes marked as internal are ignored within toObject()