### PR TITLE
Number validation - Do not set NaN in entity

### DIFF
--- a/NUAbstractModel.js
+++ b/NUAbstractModel.js
@@ -22,7 +22,7 @@ export default class NUAbstractModel extends NUObject {
             if (attributeObj.remoteName in JSONObject) {
                 const value = JSONObject[attributeObj.remoteName];
                 if (attributeObj.attributeType === NUAttribute.ATTR_TYPE_INTEGER || attributeObj.attributeType === NUAttribute.ATTR_TYPE_FLOAT) {
-                    this[localName] = (!value && value !== 0) ? null : Number(value);
+                    this[localName] = (!value && value !== 0) ? null : isNaN(value) ? value : Number(value);
                 } else if (attributeObj.attributeType === NUAttribute.ATTR_TYPE_OBJECT && attributeObj.subType && value) {
                     const subtypeEntity = new attributeObj.subType();
                     this[localName] = subtypeEntity.buildFromJSON(value);

--- a/NUAttribute.js
+++ b/NUAttribute.js
@@ -68,10 +68,10 @@ export default class NUAttribute extends NUObject {
                     'Invalid input', 'This value is mandatory');
             }
 
-            if (attrValue) {
+            if (attrValue !== undefined && attrValue !== null) {
                 var dataTypeMismatch = false;
                 if (attrObj.attributeType === NUAttribute.ATTR_TYPE_INTEGER || attrObj.attributeType === NUAttribute.ATTR_TYPE_FLOAT || attrObj.attributeType === NUAttribute.ATTR_TYPE_LONG || attrObj.attributeType === NUAttribute.ATTR_TYPE_TIMESTAMP) {
-                    dataTypeMismatch = (typeof attrValue !== 'number');
+                    dataTypeMismatch = isNaN(attrValue);
                 } else if (attrObj.attributeType === NUAttribute.ATTR_TYPE_LIST) {
                     dataTypeMismatch = (typeof attrValue !== 'object');
                 } else if (attrObj.attributeType !== NUAttribute.ATTR_TYPE_ENUM && typeof attrValue !== attrObj.attributeType) {


### PR DESCRIPTION
Issue: NaN was being set in entity, which was being considered as no value, resulting in skipping of validation checks

Fix
1. For a number attribute, set value in form as is if isNaN passes
2. `typeof NaN` is number, hence changed validation check in NUAttribute

Sample:
<img width="445" alt="Screen Shot 2019-06-11 at 4 10 51 PM" src="https://user-images.githubusercontent.com/24920919/59313064-48f2ca00-8c64-11e9-8c81-3d12af205f2d.png">
