### PR TITLE
Should clause with advanced filter fix

### DIFF
--- a/elasticsearch/ESService.js
+++ b/elasticsearch/ESService.js
@@ -115,7 +115,18 @@ export default class ESService {
             return queryConfiguration;
 
         if (search.length) {
-            objectPath.push(queryConfiguration, 'query.body.query.bool.must', ESSearchConvertor(search));
+            if (objectPath.has(queryConfiguration, 'query.body.query.bool.should')) {
+                const allShould = objectPath.get(queryConfiguration, 'query.body.query.bool.should');
+                if (Array.isArray(allShould)) {
+                    allShould.map(item => {
+                        objectPath.push(item, 'bool.must', ESSearchConvertor(search))
+                    })
+                } else {
+                    objectPath.push(queryConfiguration, 'query.body.query.bool.should', ESSearchConvertor(search))
+                }
+            } else {
+                objectPath.push(queryConfiguration, 'query.body.query.bool.must', ESSearchConvertor(search));
+            }
         }
 
         return queryConfiguration;


### PR DESCRIPTION
When the search uses should the filters must be added to each individual bool.must clause.


@nxanil this will fix the latest issues with filters and advanced filters. Please review. Will push in to get it verified.