### PR TITLE
custom delimiter for concatenationFields

### DIFF
--- a/elasticsearch/ESTabify.js
+++ b/elasticsearch/ESTabify.js
@@ -90,7 +90,7 @@ export default class ESTabify {
                     value = dataSet.map(data => method ? method(data) : data[joinField.field])
                         .filter(value => value);
 
-                    value = _.uniq(value).join(', ');
+                    value = _.uniq(value).join(`${joinField.delimiter ? joinField.delimiter : ','} `);
                 } else {
                     value = dataSet && typeof dataSet === 'object' ? dataSet[joinField.field] : dataSet;
                 }


### PR DESCRIPTION
Added changes to use a custom delimiter from tabifyOptions configuration 

Sample config:
```
"tabifyOptions": {
    "concatenationFields": [
        {
            "path": "AppStack",
            "field": "value",
            "delimiter": " /"
        }
    ]
}
```
Corresponding tabified Appstack field in table:
<img width="1108" alt="Screen Shot 2019-09-19 at 2 08 44 PM" src="https://user-images.githubusercontent.com/24920919/65281266-08b6a980-dae7-11e9-92a6-c92988de9fb7.png">
