### PR TITLE
attribute validation - support for list of validators

### DIFF
--- a/NUAbstractModel.js
+++ b/NUAbstractModel.js
@@ -1,6 +1,13 @@
 import NUAttribute from './NUAttribute';
 import NUObject from './NUObject';
+import isEmpty from 'lodash/isEmpty';
 
+const doValidate = (validator, entity, attrObj, formValues) => {
+    const validationError = validator.validate(entity, attrObj, formValues);
+    if (validationError) {
+        entity.validationErrors.set(validator.name, validationError);
+    }
+}
 /*
   This class models the base Entity
 */
@@ -86,7 +93,17 @@ export default class NUAbstractModel extends NUObject {
         Register custom validator
     */
     registerValidator(...args) {
-        this._validators.set(args[0].name, args[0]);
+        if (args.length == 2 && args[1]) {
+            //if the second argument is true, the new validator will be appended to the list of existing validators
+            const currentValidator = this._validators.get(args[0].name) || [];
+            if (Array.isArray(currentValidator)) {
+                this._validators.set(args[0].name, [...currentValidator, args[0]]);
+            } else {
+                this._validators.set(args[0].name, [currentValidator, args[0]]);
+            }
+        } else {
+            this._validators.set(args[0].name, args[0]);
+        }
     }
 
     isValid(formValues) {
@@ -99,9 +116,12 @@ export default class NUAbstractModel extends NUObject {
         const entity = this;
         entity._validators.forEach((validator, attributeName) => {
             const attrObj = this.constructor.attributeDescriptors[attributeName];
-            const validationError = validator.validate(entity, attrObj, formValues);
-            if (validationError) {
-                entity.validationErrors.set(validator.name, validationError);
+            if (Array.isArray((validator))) {
+                validator.forEach(validatorItem => {
+                    doValidate(validatorItem, entity, attrObj, formValues);
+                })
+            } else {
+                doValidate(validator, entity, attrObj, formValues);
             }
         });
     }

--- a/NUAbstractModel.js
+++ b/NUAbstractModel.js
@@ -1,6 +1,5 @@
 import NUAttribute from './NUAttribute';
 import NUObject from './NUObject';
-import isEmpty from 'lodash/isEmpty';
 
 const doValidate = (validator, entity, attrObj, formValues) => {
     const validationError = validator.validate(entity, attrObj, formValues);


### PR DESCRIPTION
If a second argument pass to registerValidator() is true, the new validator will be appended to the list of existing validators

Sample:
![customvalidator](https://user-images.githubusercontent.com/24920919/76128436-2efad380-5fb9-11ea-9f77-0fee48dfbf8e.gif)
