### PR TITLE
fix getDefaults

### DIFF
--- a/NUEntity.js
+++ b/NUEntity.js
@@ -138,7 +138,7 @@ export default class NUEntity extends NUAbstractModel {
 
     getDefaults() {
         return Object.entries(this).reduce((acc, [key, value]) => {
-            return (value && key !== '_validationErrors' && key !== '_validators' && key !== '_associatedEntities')
+            return (value !== undefined && value !== null && key !== '_validationErrors' && key !== '_validators' && key !== '_associatedEntities')
                 ? { ...acc, [key.substring(1)]: value } : acc;
         }, {});
     }


### PR DESCRIPTION
- found while writing tests for editor in create mode
- if initial value for an attribute is false in model (same would apply to 0 as well), the same does not get picked up in initialValues for the form