### PR TITLE
fix NUEntity.hasMandatoryAttributesSet

### DIFF
--- a/NUAttribute.js
+++ b/NUAttribute.js
@@ -51,6 +51,12 @@ export default class NUAttribute extends NUObject {
             isInternal: obj.isInternal,
         });
     }
+    
+
+    isValueSet(attrValue) {
+        return ((this.attributeType === NUAttribute.ATTR_TYPE_STRING && attrValue) ||
+            (this.attributeType !== NUAttribute.ATTR_TYPE_STRING && attrValue !== undefined && attrValue !== null));
+    }
 
     /*
         Invoked from NUEntity.
@@ -62,8 +68,7 @@ export default class NUAttribute extends NUObject {
         if (attrObj) {
             const attrValue =  entity && entity[attrObj.name];
             //if STRING use !attrValue to check if value provided. For all other attribute types use !undefined and !null
-            if (attrObj.isRequired && ((attrObj.attributeType === NUAttribute.ATTR_TYPE_STRING && !attrValue) ||
-                (attrObj.attributeType !== NUAttribute.ATTR_TYPE_STRING && (attrValue === undefined || attrValue === null)))) {
+            if (attrObj.isRequired && !attrObj.isValueSet(attrValue)) {
                 return new NUAttributeValidationError(attrObj.localName, attrObj.remoteName,
                     'Invalid input', 'This value is mandatory');
             }

--- a/NUEntity.js
+++ b/NUEntity.js
@@ -87,11 +87,10 @@ export default class NUEntity extends NUAbstractModel {
         }
         return this.mandatoryAttributes;
     }
-    
+
     static hasMandatoryAttributesSet(JSONObject) {
-        for (const attr of this.getMandatoryAttributes()) {
-            const attrValue = JSONObject[attr];
-            if (attrValue === null || attrValue === undefined) {
+        for (const [attr, descriptor] of Object.entries(this.attributeDescriptors)) {
+            if (descriptor.isRequired && !descriptor.isValueSet(JSONObject[attr])) {
                 return false;
             }
         }

--- a/NUEntity.js
+++ b/NUEntity.js
@@ -73,21 +73,6 @@ export default class NUEntity extends NUAbstractModel {
         return this.searchableAttributes;
     }
 
-    static getMandatoryAttributes() {
-        if (!this.mandatoryAttributes) {
-            this.mandatoryAttributes = Object
-                .entries(this.attributeDescriptors)
-                .reduce((acc, attr) => {
-                    const [key, value] = attr;
-                    if (value.isRequired) {
-                        acc.push(key)
-                    };
-                    return acc;
-                }, []);
-        }
-        return this.mandatoryAttributes;
-    }
-
     static hasMandatoryAttributesSet(JSONObject) {
         for (const [attr, descriptor] of Object.entries(this.attributeDescriptors)) {
             if (descriptor.isRequired && !descriptor.isValueSet(JSONObject[attr])) {

--- a/NUEntity.js
+++ b/NUEntity.js
@@ -90,7 +90,8 @@ export default class NUEntity extends NUAbstractModel {
     
     static hasMandatoryAttributesSet(JSONObject) {
         for (const attr of this.getMandatoryAttributes()) {
-            if (!JSONObject[attr]) {
+            const attrValue = JSONObject[attr];
+            if (attrValue === null || attrValue === undefined) {
                 return false;
             }
         }


### PR DESCRIPTION
- unable to edit untagged vlan
- hasMandatoryAttributesSet is used within isFormDirty selector
- vlan with `value` as `0` was making hasMandatoryAttributesSet return `false`