### PR TITLE
validate min/max values of number type attributes

### DIFF
--- a/NUAttribute.js
+++ b/NUAttribute.js
@@ -16,6 +16,7 @@ export default class NUAttribute extends NUObject {
     static ATTR_TYPE_STRING = 'string';
     static ATTR_TYPE_OBJECT = 'object';
     static ATTR_TYPE_TIMESTAMP = 'long';
+    static ATTR_TYPES_NUMBER = [NUAttribute.ATTR_TYPE_INTEGER, NUAttribute.ATTR_TYPE_FLOAT, NUAttribute.ATTR_TYPE_LONG];
 
     constructor(obj) {
         super();
@@ -49,6 +50,8 @@ export default class NUAttribute extends NUObject {
             subType: obj.subType,
             userlabel: obj.userlabel,
             isInternal: obj.isInternal,
+            minValue: obj.minValue,
+            maxValue: obj.maxValue
         });
     }
     
@@ -96,6 +99,8 @@ export default class NUAttribute extends NUObject {
                 }
                 else if (attrObj.attributeType === NUAttribute.ATTR_TYPE_OBJECT) {
                     return attrObj.validateObjectValue(attrValue, attrObj);
+                } else if (NUAttribute.ATTR_TYPES_NUMBER.includes(attrObj.attributeType)) {
+                    return attrObj.validateNumberValue(attrValue, attrObj);
                 }
             }
         }
@@ -173,5 +178,18 @@ export default class NUAttribute extends NUObject {
             }
         }
         return null;
+    }
+
+    validateNumberValue(attrValue, attrObj) {
+        if (!isNaN(attrObj.minValue) && (isNaN(attrValue) || attrValue < attrObj.minValue)) {
+            return new NUAttributeValidationError(attrObj.localName, attrObj.remoteName,
+                'Invalid value',
+                `Minimum accepted value is ${attrObj.minValue}`);
+        }
+        if (!isNaN(attrObj.maxValue) && (isNaN(attrValue) || attrValue > attrObj.maxValue)) {
+            return new NUAttributeValidationError(attrObj.localName, attrObj.remoteName,
+                'Invalid value',
+                `Maximum accepted value is ${attrObj.maxValue}`);
+        }
     }
 }


### PR DESCRIPTION
Works with code generator changes: https://github.com/nuagenetworks/monolithe/pull/150

Sample:
<img width="377" alt="Screen Shot 2020-03-27 at 3 06 00 PM" src="https://user-images.githubusercontent.com/24920919/77806461-00b16680-7042-11ea-9daa-945a5a70445e.png">
<img width="662" alt="Screen Shot 2020-03-27 at 3 39 49 PM" src="https://user-images.githubusercontent.com/24920919/77806459-ff803980-7041-11ea-8ceb-d9d5294cc2ec.png">