### PR TITLE
Pass verb and body to onMultipleChoices

### DIFF
--- a/NURESTConnection.js
+++ b/NURESTConnection.js
@@ -157,6 +157,18 @@ export default class NURESTConnection extends NUObject {
         }
     }
 
+    static _parseStringToJSON = (string) => {
+        if (!string) {
+            return "";
+        }
+        try {
+            return typeof string === 'string' ? JSON.parse(string) : string;
+        }
+        catch (e) {
+            return string;
+        }
+    }
+
     /*
       Generic method for invoking HTTP/REST requests on the server
     */
@@ -189,7 +201,7 @@ export default class NURESTConnection extends NUObject {
 
             //handle response with choice
             if (response.status === 300 && this._onMultipleChoices) {
-                return this._onMultipleChoices(response.data, requestURL, verb, body)
+                return this._onMultipleChoices(response.data, requestURL, verb, _parseStringToJSON(body))
                     .then(choice => this.makeRequest({requestURL, verb, headers, body, choice, cancelToken}));
             }
 

--- a/NURESTConnection.js
+++ b/NURESTConnection.js
@@ -201,7 +201,7 @@ export default class NURESTConnection extends NUObject {
 
             //handle response with choice
             if (response.status === 300 && this._onMultipleChoices) {
-                return this._onMultipleChoices(response.data, requestURL, verb, _parseStringToJSON(body))
+                return this._onMultipleChoices(response.data, requestURL, verb, NURESTConnection._parseStringToJSON(body))
                     .then(choice => this.makeRequest({requestURL, verb, headers, body, choice, cancelToken}));
             }
 

--- a/NURESTConnection.js
+++ b/NURESTConnection.js
@@ -189,7 +189,7 @@ export default class NURESTConnection extends NUObject {
 
             //handle response with choice
             if (response.status === 300 && this._onMultipleChoices) {
-                return this._onMultipleChoices(response.data, requestURL)
+                return this._onMultipleChoices(response.data, requestURL, verb, body)
                     .then(choice => this.makeRequest({requestURL, verb, headers, body, choice, cancelToken}));
             }
 

--- a/NURESTConnection.js
+++ b/NURESTConnection.js
@@ -157,15 +157,15 @@ export default class NURESTConnection extends NUObject {
         }
     }
 
-    static _parseStringToJSON = (string) => {
-        if (!string) {
-            return "";
+    static _parseStringToJSON = (input) => {
+        if (!input) {
+            return {};
         }
         try {
-            return typeof string === 'string' ? JSON.parse(string) : string;
+            return typeof input === 'string' ? JSON.parse(input) : input;
         }
         catch (e) {
-            return string;
+            return input;
         }
     }
 


### PR DESCRIPTION
This will be used for VSD-41009 to remove jobs from store, when a job is cancelled from multiple choice alert.
Passing body as an object so to avoid parsing at multiple places in vsd-react-ui