### PR TITLE
VSD-51867 Fixing No Data in Heatmap

### DIFF
--- a/tabify/fecHeatmapTabify.js
+++ b/tabify/fecHeatmapTabify.js
@@ -20,6 +20,8 @@ import isEmpty from "lodash/isEmpty";
  *   ...
  * ]
  */
+const NO_DATA = 'No Data';
+
 export default class FecHeatmapTabify {
 
     getFECHeatmapColorValue(key) {
@@ -29,18 +31,18 @@ export default class FecHeatmapTabify {
             key >= 1.5 && key < 2.0 ? '1.5% - 1.99%' :
             key >= 2.0 && key < 4.0 ? '2.0% - 3.99%' : 
             key >= 4.0 && key < 6.0 ? '4.0% - 5.99%' : 
-            key >= 6.0 && key < 10.0 ? '6.0% - 9.99%' : '>= 10.0%';
+            key >= 6.0 && key < 10.0 ? '6.0% - 9.99%' : 
+            key >=10.0 ? '>= 10.0%' : NO_DATA;
     }
     
     process(response) {
         const aggregations = response && response.aggregations;
-        const NO_DATA = 'No Data';
         if (!isEmpty(aggregations)) {
             const result = [];
             if (aggregations.date_histo && aggregations.date_histo.buckets) {
                 for (const dateHistoEntry of aggregations.date_histo.buckets) {
-                    const networkLossValue = dateHistoEntry.NetworkLoss ? dateHistoEntry.NetworkLoss.value : NO_DATA;
-                    const lossAfterFecValue = dateHistoEntry.LossAfterFEC ? dateHistoEntry.LossAfterFEC.value : NO_DATA;
+                    const networkLossValue = dateHistoEntry.NetworkLoss && dateHistoEntry.NetworkLoss.value ? dateHistoEntry.NetworkLoss.value : NO_DATA;
+                    const lossAfterFecValue = dateHistoEntry.LossAfterFEC && dateHistoEntry.LossAfterFEC.value ? dateHistoEntry.LossAfterFEC.value : NO_DATA;
                     const underlayName = (dateHistoEntry.UnderlayName && dateHistoEntry.UnderlayName.buckets && dateHistoEntry.UnderlayName.buckets.length && dateHistoEntry.UnderlayName.buckets[0].key) || '-';
                     result.push({
                         key_as_string: dateHistoEntry.key_as_string,
@@ -48,8 +50,8 @@ export default class FecHeatmapTabify {
                         doc_count: 1,
                         stat: "Network Loss (%)",
                         key: networkLossValue,
-                        min: dateHistoEntry.MinNetworkLoss ? dateHistoEntry.MinNetworkLoss.value : NO_DATA,
-                        max: dateHistoEntry.MaxNetworkLoss ? dateHistoEntry.MaxNetworkLoss.value : NO_DATA,
+                        min: dateHistoEntry.MinNetworkLoss && dateHistoEntry.MinNetworkLoss.value ? dateHistoEntry.MinNetworkLoss.value : NO_DATA,
+                        max: dateHistoEntry.MaxNetworkLoss && dateHistoEntry.MaxNetworkLoss.value ? dateHistoEntry.MaxNetworkLoss.value : NO_DATA,
                         underlay: underlayName,
                         ColorValue: this.getFECHeatmapColorValue(networkLossValue)
                     },
@@ -59,8 +61,8 @@ export default class FecHeatmapTabify {
                         doc_count: 1,
                         stat: "Loss After FEC (%)",
                         key: lossAfterFecValue,
-                        min: dateHistoEntry.MinLossAfterFEC ? dateHistoEntry.MinLossAfterFEC.value : NO_DATA,
-                        max: dateHistoEntry.MaxLossAfterFEC ? dateHistoEntry.MaxLossAfterFEC.value : NO_DATA,
+                        min: dateHistoEntry.MinLossAfterFEC && dateHistoEntry.MinLossAfterFEC.value ? dateHistoEntry.MinLossAfterFEC.value : NO_DATA,
+                        max: dateHistoEntry.MaxLossAfterFEC && dateHistoEntry.MaxLossAfterFEC.value ? dateHistoEntry.MaxLossAfterFEC.value : NO_DATA,
                         underlay: underlayName,
                         ColorValue: this.getFECHeatmapColorValue(lossAfterFecValue)
                     });

--- a/tabify/fecHeatmapTabify.js
+++ b/tabify/fecHeatmapTabify.js
@@ -1,4 +1,5 @@
 import isEmpty from "lodash/isEmpty";
+import { isVariableNonNullAndDefined } from './utils';
 
 /*
  * Returns the Network Loss and Loss after FEC percentages for a given Source and Destination NSG combination in the given format
@@ -41,8 +42,8 @@ export default class FecHeatmapTabify {
             const result = [];
             if (aggregations.date_histo && aggregations.date_histo.buckets) {
                 for (const dateHistoEntry of aggregations.date_histo.buckets) {
-                    const networkLossValue = dateHistoEntry.NetworkLoss && dateHistoEntry.NetworkLoss.value ? dateHistoEntry.NetworkLoss.value : NO_DATA;
-                    const lossAfterFecValue = dateHistoEntry.LossAfterFEC && dateHistoEntry.LossAfterFEC.value ? dateHistoEntry.LossAfterFEC.value : NO_DATA;
+                    const networkLossValue = dateHistoEntry.NetworkLoss && isVariableNonNullAndDefined(dateHistoEntry.NetworkLoss.value) ? dateHistoEntry.NetworkLoss.value : NO_DATA;
+                    const lossAfterFecValue = dateHistoEntry.LossAfterFEC && isVariableNonNullAndDefined(dateHistoEntry.LossAfterFEC.value) ? dateHistoEntry.LossAfterFEC.value : NO_DATA;
                     const underlayName = (dateHistoEntry.UnderlayName && dateHistoEntry.UnderlayName.buckets && dateHistoEntry.UnderlayName.buckets.length && dateHistoEntry.UnderlayName.buckets[0].key) || '-';
                     result.push({
                         key_as_string: dateHistoEntry.key_as_string,
@@ -50,8 +51,8 @@ export default class FecHeatmapTabify {
                         doc_count: 1,
                         stat: "Network Loss (%)",
                         key: networkLossValue,
-                        min: dateHistoEntry.MinNetworkLoss && dateHistoEntry.MinNetworkLoss.value ? dateHistoEntry.MinNetworkLoss.value : NO_DATA,
-                        max: dateHistoEntry.MaxNetworkLoss && dateHistoEntry.MaxNetworkLoss.value ? dateHistoEntry.MaxNetworkLoss.value : NO_DATA,
+                        min: dateHistoEntry.MinNetworkLoss && isVariableNonNullAndDefined(dateHistoEntry.MinNetworkLoss.value) ? dateHistoEntry.MinNetworkLoss.value : NO_DATA,
+                        max: dateHistoEntry.MaxNetworkLoss && isVariableNonNullAndDefined(dateHistoEntry.MaxNetworkLoss.value) ? dateHistoEntry.MaxNetworkLoss.value : NO_DATA,
                         underlay: underlayName,
                         ColorValue: this.getFECHeatmapColorValue(networkLossValue)
                     },
@@ -61,8 +62,8 @@ export default class FecHeatmapTabify {
                         doc_count: 1,
                         stat: "Loss After FEC (%)",
                         key: lossAfterFecValue,
-                        min: dateHistoEntry.MinLossAfterFEC && dateHistoEntry.MinLossAfterFEC.value ? dateHistoEntry.MinLossAfterFEC.value : NO_DATA,
-                        max: dateHistoEntry.MaxLossAfterFEC && dateHistoEntry.MaxLossAfterFEC.value ? dateHistoEntry.MaxLossAfterFEC.value : NO_DATA,
+                        min: dateHistoEntry.MinLossAfterFEC && isVariableNonNullAndDefined(dateHistoEntry.MinLossAfterFEC.value) ? dateHistoEntry.MinLossAfterFEC.value : NO_DATA,
+                        max: dateHistoEntry.MaxLossAfterFEC && isVariableNonNullAndDefined(dateHistoEntry.MaxLossAfterFEC.value) ? dateHistoEntry.MaxLossAfterFEC.value : NO_DATA,
                         underlay: underlayName,
                         ColorValue: this.getFECHeatmapColorValue(lossAfterFecValue)
                     });

--- a/tabify/fecHeatmapTabify.js
+++ b/tabify/fecHeatmapTabify.js
@@ -32,7 +32,7 @@ export default class FecHeatmapTabify {
             key >= 2.0 && key < 4.0 ? '2.0% - 3.99%' : 
             key >= 4.0 && key < 6.0 ? '4.0% - 5.99%' : 
             key >= 6.0 && key < 10.0 ? '6.0% - 9.99%' : 
-            key >=10.0 ? '>= 10.0%' : NO_DATA;
+            key >= 10.0 ? '>= 10.0%' : NO_DATA;
     }
     
     process(response) {

--- a/tabify/utils.js
+++ b/tabify/utils.js
@@ -1,0 +1,1 @@
+export const isVariableNonNullAndDefined = varValue => varValue !== undefined && varValue !== null;


### PR DESCRIPTION
Description:
- The `No Data` part was not working properly in FEC heatmap as `getFECHeatmapColorValue` was missing the condition for it and also when the conditional operator `dateHistoEntry.NetworkLoss ? dateHistoEntry.NetworkLoss.value : NO_DATA` condition should be `dateHistoEntry.NetworkLoss && dateHistoEntry.NetworkLoss.value ? dateHistoEntry.NetworkLoss.value : NO_DATA` to account for null values.

Before:
![image](https://user-images.githubusercontent.com/46327518/108181023-447ae780-70bc-11eb-9a3c-9fa4c66310e4.png)

After:
![image](https://user-images.githubusercontent.com/46327518/108181054-4e044f80-70bc-11eb-96c4-2ff55098ad33.png)
