### PR TITLE
Include ES index column types from mapping response

### DIFF
--- a/elasticsearch/ESRESTConnection.js
+++ b/elasticsearch/ESRESTConnection.js
@@ -115,10 +115,11 @@ export default class ESRESTConnection extends NUObject {
             if (objectPath.has(val, 'properties')) {
                 this.getESColumns(Object.values(val), parentKey ? `${parentKey}.${key}` : key, columns);
             } else {
+                const type = val ? val.type : null;
                 if (parentKey === null) {
-                    columns.push({key : key, nested : isNestedColumn });
+                    columns.push({key : key, nested : isNestedColumn, type });
                 } else {
-                    columns.push({key: `${parentKey}.${key}`, nested : isNestedColumn});
+                    columns.push({key: `${parentKey}.${key}`, nested : isNestedColumn, type});
                 }
             }
         });


### PR DESCRIPTION
- This is required for https://github.com/nuagenetworks/vis-graphs/pull/450 to work as expected, type from mapping response is to be captured