### PR TITLE
VSD-53375 Do not clear the APIKey in updatePwd

### DIFF
--- a/NUService.js
+++ b/NUService.js
@@ -190,7 +190,6 @@ export default class NUService extends NUObject {
         requestPayLoad.password = entity.newPassword;
         requestPayLoad.passwordConfirm = entity.newPassword;
         requestPayLoad = JSON.stringify(requestPayLoad);
-        this.APIKey = null;
         
         return this.invokeRequest({
             verb: 'PUT',


### PR DESCRIPTION
Do not clear the APIKey when updatePassword is called. Reference to vsd-react-ui code in Editor/actions. When the Promise is successful, user should log out. We should not reset the APIKey here because the update password may fail and then all the calls will fail as the key is reset.