### PR TITLE
BulkDelete functinality

### DIFF
--- a/NURESTConnection.js
+++ b/NURESTConnection.js
@@ -284,8 +284,8 @@ export default class NURESTConnection extends NUObject {
     /*
       Invokes a DELETE request on the server
     */
-    makeDELETERequest(requestURL, headers, cancelToken) {
-        return this.makeRequest({requestURL, verb: 'DELETE', headers, cancelToken});
+    makeDELETERequest(requestURL, headers, body, cancelToken) {
+        return this.makeRequest({requestURL, verb: 'DELETE', headers, body, cancelToken});
     }
 
     /*

--- a/NUService.js
+++ b/NUService.js
@@ -156,6 +156,21 @@ export default class NUService extends NUObject {
         return url;
     }
 
+    buildBulkURL(entities) {
+        if (!Array.isArray(entities) || entities.length < 1) {
+            return null;
+        }
+
+        let url = `${this.rootURL}/${entities[0].data.resourceName}?responseChoice=1`;
+        entities.forEach(({data}) => 
+            {
+                url += `&id=${data.ID}`
+            }
+        );
+
+        return url;
+    }
+
     /*
       Logs in to VSD, processes the APIKey received in the response,
       and stores the same APIKey for future invocations
@@ -352,6 +367,19 @@ export default class NUService extends NUObject {
     }
 
     /*
+      Issues a Bulk DELETE request on the entity for the selected items
+    */
+    deleteAll(entities, cancelToken) {
+        return this.invokeRequest({
+            verb: 'DELETE',
+            requestURL: this.buildBulkURL(entities),
+            headers: this.computeHeaders(),
+            requestData: '[]',
+            cancelToken
+        });
+    }
+
+    /*
       Issues a HEAD request, processes response, and resolves the count of entities
     */
     count({
@@ -419,7 +447,7 @@ export default class NUService extends NUObject {
         } else if (verb === 'POST') {
             return this._connection.makePOSTRequest(requestURL, headers, requestData, cancelToken);
         } else if (verb === 'DELETE') {
-            return this._connection.makeDELETERequest(requestURL, headers, cancelToken);
+            return this._connection.makeDELETERequest(requestURL, headers, requestData, cancelToken);
         } else if (verb === 'HEAD') {
             return this._connection.makeHEADRequest(requestURL, headers, cancelToken);
         } else if (verb === 'PATCH') {


### PR DESCRIPTION
Background: When multiple objects are selected in the list data view and delete is clicked, earlier we looped thru the selection and fired individual DELETE API calls. For VPort this was not OK as the server has to do some manipulations when the last vport/interface was deleted. So there was a need to do a bulk delete call, that way server will know when it is deleting the last object.

Fix: Adding deleteAll functionality in NUSerice. In react ui where ever needed we can call deleteAll instead of delete call. 
For now using deleteAll only for vport delete as the bulk delete is supported by server only for vports

Since VPort can have interfaces attached to it and interface can be of many types, and bulk delete is only for multiple ids of the same enitity we have to call bulk delete for each of the interface types, then finall call bulk delete on the vports.

Here is an example:

Request URL: https://135.227.4.86:8443/nuage/api/v6/bridgeinterfaces?responseChoice=1&id=a642266e-b423-11eb-8ac4-97216f98368b
Request URL: https://135.227.4.86:8443/nuage/api/v6/hostinterfaces?responseChoice=1&id=733eea7f-b423-11eb-8ac4-8b0fdc258bfa
Request URL: https://135.227.4.86:8443/nuage/api/v6/vports?responseChoice=1&id=a58a20d9-b423-11eb-8ac4-7fd631714971&id=7288e0b9-b423-11eb-8ac4-8b6828ce8b25

Here 2 vports were selected, 1st one has a bridge interface, 2nd has a host interface.