### PR TITLE
Fixed Tier1 and Tier2 graph title timestamp conversion issue VSD-58072

### DIFF
--- a/NUTemplateParser/NUParser.js
+++ b/NUTemplateParser/NUParser.js
@@ -99,8 +99,10 @@ const parseString = (() => {
                 context = context || {};
                 return matches.reduce((str, match, i) => {
                     const parameter = parameters[i];
-
-                    const value = context[parameter.key] || parameter.defaultValue;
+                    let value = context[parameter.key] || parameter.defaultValue;
+                    if(parameter.evaluate === "time_convert") {
+                        value = new Date(parseInt(value));
+                    }
                     return Array.isArray(value) ? value : str.replace(match, value);
                 }, str);
             }, parameters);


### PR DESCRIPTION
@jopidoo  @edwinfeener 

Fixed IKE - probe stats - timestamps in title of ES record are not human readable [VSD-58072]( http://mvjira.mv.usa.alcatel.com:8080/browse/VSD-58072).

![graphTitle](https://user-images.githubusercontent.com/47311742/188824885-d7639698-4a47-4635-8678-31f3b65548ac.png)


Please review the PR