### PR TITLE
PROD-13476 add a param notToIncludeEntityID to buildURL method in NUS…

### DIFF
--- a/NUService.js
+++ b/NUService.js
@@ -139,7 +139,12 @@ export default class NUService extends NUObject {
         return `XREST ${btoa(`${this.userName}:${(this.APIKey || this.password)}`)}`;
     }
 
-    buildURL(entity, RESTResourceName, parentEntity) {
+    /*
+      Since R13 introduced a cloneFrom attribute for one NUObject, 
+      an entity being cloned has entity.ID but it shouldn't be built into the url,
+      notToIncludeEntityID flag is to determine if url needs to include entity.ID or not.
+    */
+    buildURL(entity, RESTResourceName, parentEntity, notToIncludeEntityID) {
         let url = `${this.rootURL}/`;
 
         if (!entity) {
@@ -150,7 +155,7 @@ export default class NUService extends NUObject {
                 `${parentEntity.resourceName}/${parentEntity.ID}/${resourceName}`;
         } else {
             url += ((!parentEntity) ? '' : `${parentEntity.resourceName}/${parentEntity.ID}/`) +
-                entity.resourceName + (entity.resourceName === 'me' ? '' : ((entity.ID !== null) ? (`/${entity.ID}`) : ''));
+                entity.resourceName + (entity.resourceName === 'me' ? '' : ((entity.ID !== null && !notToIncludeEntityID) ? (`/${entity.ID}`) : ''));
         }
 
         return url;
@@ -355,7 +360,7 @@ export default class NUService extends NUObject {
     create(entity, parentEntity, cancelToken) {
         return this.invokeRequest({
             verb: 'POST',
-            requestURL: this.buildURL(entity, null, parentEntity),
+            requestURL: this.buildURL(entity, null, parentEntity, true),
             headers: this.computeHeaders(),
             requestData: entity.buildJSON(),
             cancelToken


### PR DESCRIPTION
**JIRA**: PROD-13377

**Description**:
After "clone" action is introduced for Statistics Profile, the "buildURL" function of "NUService.js" needs to have an extra param "notToIncludeEntityID" to determine if "entityID" needs to be include in the url. Prior to "clone", "edit" action is the only situation that entityID needs to be built in the url, but with "clone" action "entityID" is already presented at the time when an object is cloned, but it is a "POST" to create a new object so we don't want "entityID" built in the url. Since "buildURL" is called by different callers, when a caller doesn't pass "notToIncludeEntityID" it is null, any existing behavior won't be affected.